### PR TITLE
Use root context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY application.properties /app/application.properties
 
 EXPOSE 8080
 
-ENTRYPOINT [ "java", "-jar", "/app/app.jar" , "--spring.profiles.active=kadmin,local"]
+ENTRYPOINT [ "java", "-jar", "/app/app.jar" , "--spring.profiles.active=kadmin,local", "--server.contextPath=/"]


### PR DESCRIPTION
Since this is being run via docker and is the only thing being served no need to add context

this now works with http://localhost:8080 instead of http://localhost:8080/kadmin