### PR TITLE
List kafka topics without using schema registry

### DIFF
--- a/src/main/java/com/bettercloud/kadmin/api/services/IntrospectionService.java
+++ b/src/main/java/com/bettercloud/kadmin/api/services/IntrospectionService.java
@@ -1,0 +1,10 @@
+package com.bettercloud.kadmin.api.services;
+
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface IntrospectionService {
+	
+	Collection<String> getAllTopicNames(Optional<String> kafkaUrl);
+}

--- a/src/main/java/com/bettercloud/kadmin/io/network/rest/SchemaProxyResource.java
+++ b/src/main/java/com/bettercloud/kadmin/io/network/rest/SchemaProxyResource.java
@@ -1,8 +1,9 @@
 package com.bettercloud.kadmin.io.network.rest;
 
 import com.bettercloud.kadmin.api.kafka.exception.SchemaRegistryRestException;
-import com.bettercloud.kadmin.io.network.dto.SchemaInfoModel;
+import com.bettercloud.kadmin.api.services.IntrospectionService;
 import com.bettercloud.kadmin.api.services.SchemaRegistryService;
+import com.bettercloud.kadmin.io.network.dto.SchemaInfoModel;
 import com.bettercloud.util.LoggerUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,10 +28,12 @@ public class SchemaProxyResource {
     private static final Logger LOGGER = LoggerUtils.get(SchemaProxyResource.class);
 
     private final SchemaRegistryService schemaRegistryService;
+    private final IntrospectionService introspectionService;
 
     @Autowired
-    public SchemaProxyResource(SchemaRegistryService schemaRegistryService) {
+    public SchemaProxyResource(SchemaRegistryService schemaRegistryService, IntrospectionService introspectionService) {
         this.schemaRegistryService = schemaRegistryService;
+        this.introspectionService = introspectionService;
     }
 
     @RequestMapping(
@@ -52,11 +56,11 @@ public class SchemaProxyResource {
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<List<String>> topics(@RequestParam("url") Optional<String> oUrl) {
+    public ResponseEntity<Collection<String>> topics(@RequestParam("kafka-url") Optional<String> kafkaUrl) {
         try {
-            return ResponseEntity.ok(schemaRegistryService.guessAllTopics(oUrl.orElse(null)));
-        } catch (SchemaRegistryRestException e) {
-            return ResponseEntity.status(e.getStatusCode())
+            return ResponseEntity.ok(introspectionService.getAllTopicNames(kafkaUrl));
+        } catch (Exception e) {
+            return ResponseEntity.status(500)
                     .header("error-message", e.getMessage())
                     .body(null);
         }

--- a/src/main/java/com/bettercloud/kadmin/services/DefaultIntrospectionService.java
+++ b/src/main/java/com/bettercloud/kadmin/services/DefaultIntrospectionService.java
@@ -1,0 +1,40 @@
+package com.bettercloud.kadmin.services;
+
+import com.bettercloud.kadmin.api.services.IntrospectionService;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+@Service
+public class DefaultIntrospectionService implements IntrospectionService {
+	
+	private String defaultKafkaHost;
+	
+	@Autowired
+	public DefaultIntrospectionService(@Value("${kafka.host:localhost:9092}") String defaultKafkaHost) {
+		this.defaultKafkaHost = defaultKafkaHost;
+	}
+	
+	@Override
+	public Collection<String> getAllTopicNames(Optional<String> kafkaUrl) {
+		Set<String> topics;
+		
+		Properties props = new Properties();
+		props.put("bootstrap.servers", kafkaUrl.orElse(defaultKafkaHost));
+		props.put("group.id", "kadmin-topic-listing-group");
+		props.put("key.deserializer", StringDeserializer.class);
+		props.put("value.deserializer", StringDeserializer.class);
+		
+		KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
+		topics = consumer.listTopics().keySet();
+		consumer.close();
+		return topics;
+	}
+}

--- a/src/main/resources/static/basicproducer/main.js
+++ b/src/main/resources/static/basicproducer/main.js
@@ -29,8 +29,13 @@ function initMain() {
     App.producer.$aceMessage.getSession().setMode("ace/mode/text");
 }
 
+function getKafkaHost() {
+    var kafkaHost = $('#kafkahost').val();
+    return kafkaHost !== "" ? kafkaHost : undefined;
+}
+
 function refreshTopics() {
-    $.get(App.contextPath + "/api/topics", handleNewTopics);
+    $.get(App.contextPath + "/api/topics", {"kafka-url": getKafkaHost()}, handleNewTopics);
 }
 
 function handleNewTopics(data) {

--- a/src/main/resources/static/consumer/main.js
+++ b/src/main/resources/static/consumer/main.js
@@ -55,8 +55,14 @@ function initMain() {
     }
 }
 
+
+function getKafkaHost() {
+    var kafkaHost = $('#kafkahost').val();
+    return kafkaHost !== "" ? kafkaHost : undefined;
+}
+
 function refreshTopics() {
-    $.get(App.contextPath + "/api/topics", handleNewTopics);
+    $.get(App.contextPath + "/api/topics", {"kafka-url": getKafkaHost()}, handleNewTopics);
 }
 
 function handleNewTopics(data) {

--- a/src/main/resources/static/producer/main.js
+++ b/src/main/resources/static/producer/main.js
@@ -39,8 +39,14 @@ function initMain() {
     App.producer.$aceSchema.getSession().setMode("ace/mode/json");
 }
 
+
+function getKafkaHost() {
+    var kafkaHost = $('#kafkahost').val();
+    return kafkaHost !== "" ? kafkaHost : undefined;
+}
+
 function refreshTopics() {
-    $.get(App.contextPath + "/api/topics", handleNewTopics);
+    $.get(App.contextPath + "/api/topics", {"kafka-url": getKafkaHost()}, handleNewTopics);
 }
 
 function handleNewTopics(data) {


### PR DESCRIPTION
What has been done?
1. A sample kafka consumer is used to list all topics (ohh this is supported since 0.9.0)
2. Frontend optionally sends custom kafka host for fetching topic list
3. Schema registry is not anymore used for "guessing topic names"

Future plans :
- Cache the kafka consumer and reuse it to fetch fresh list of topics
- Make the topic list searchable in frontend
- Dont show the topics which are marked for deletion
